### PR TITLE
FIX: Typo in latLon properties

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -33,8 +33,8 @@ declare module 'ivao-whazzup' {
         public vid: number
         public name: string
         public clientType: Client
-        public latitiude: number
-        public longtitude: number
+        public latitude: number
+        public longitude: number
         public altitude: number
         public connectionTime: number
         public softwareName: string

--- a/src/models/ivao-client.ts
+++ b/src/models/ivao-client.ts
@@ -5,8 +5,8 @@ export class IvaoClient {
     public vid: number
     public name: string
     public clientType: Client
-    public latitiude: number
-    public longtitude: number
+    public latitude: number
+    public longitude: number
     public altitude: number
     public connectionTime: number
     public softwareName: string
@@ -20,8 +20,8 @@ export class IvaoClient {
         this.softwareName = clientData[38]
         this.softwareVersion = clientData[39]
         this.clientType = clientData[3] as Client
-        this.latitiude = parseFloat(clientData[5])
-        this.longtitude = parseFloat(clientData[6])
+        this.latitude = parseFloat(clientData[5])
+        this.longitude = parseFloat(clientData[6])
         this.altitude = parseInt(clientData[7], 10)
     }
 


### PR DESCRIPTION
The model for IvaoClient had a couple of typos for the latitude and longitude properties, noticed it while using your library in one of my projects. Handled it client side, but I guess you wouldn't mind fixing it directly.