### PR TITLE
ci: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,8 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "build"


### PR DESCRIPTION
Sets target branch to develop as well as configure default commit prefix.