### PR TITLE
refactor!: drop support for Node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
           - 15
           - 14
           - 12
-          - 10
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   },
   "dependencies": {
     "axios": "^0.21.0"
+  },
+  "engines": {
+    "node": ">= 12.0.0"
   }
 }


### PR DESCRIPTION
Since Node 10 is now out of support, we're dropping the support for it.